### PR TITLE
Query userData after waiting for giveaways

### DIFF
--- a/igautoenter.user.js
+++ b/igautoenter.user.js
@@ -81,13 +81,13 @@
       return;
     }
     try {
+      await waitForGiveaways();
       const [userData, ownedGames] = await Promise.all([
         withFailSafeAsync(getUserData)(),
         withFailSafeAsync(getOwnedGames)()
       ]);
       setUserData(userData);
       setOwnedGames(ownedGames);
-      await waitForGiveaways();
       while (okToContinue()) {
         log("currentPage: %s, myData:", state.currentPage, my);
         const giveaways = parseGiveaways();


### PR DESCRIPTION
I've noticed that sometimes the result of userData is some valid json with `unknown` values. The script fails to catch this and tries to get tickets for giveaways which aren't in the users level range.
While ignoring the parsing issue itself I haven't gotten that error since I've moved the lines around so it seems to be far more reliable to wait for the giveaways to appear first and then fetch the user data.